### PR TITLE
Splitting standalone & kubernetes branches to clarify the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Lightweight implementation of Kubernetes Network Policies (translating them into
 
 ## Release state
 
-* Ready for Kubernetes
-* Still WIP for standalone (nearly ready, there is a non-critical bug I would
-  like to resolve) 
+* Ready and Stable for Kubernetes (tested heavily as a DaemonSet).
 
 ## Quick Usage
 
@@ -18,41 +16,50 @@ Lightweight implementation of Kubernetes Network Policies (translating them into
 
 #### As a binary on Workers
 
+Assuming your kubeconfig is in `~/.kube/config` on the Worker and the current
+user is privileged (it is needed to use iptables/ipsets):
+
 `kubefw --kubeconfig ~/.kube/config`
-
-### Outside a Kubernetes cluster
-
-This usage can be used for whatever reason
-
-For example, to allow remote troubleshooting of all the iptables across all nodes generated from Network Policies on a single machine
-
-Or even use the Network Policies "logic" on machines completely unrelated to Kubernetes ([Still a WIP])
-
-#### On a remote machine or a machine not hosting pods
-
-`kubefw --kubeconfig ~/.kube/config --standalone`
 
 or if you don't wanna use a standalone binary
 
-``docker start `docker create --net=host --rm --privileged -v ~/.kube/config:/kconfig -v /var/lib/kubernetes/:/var/lib/kubernetes/ -ti jpmondet/kubefw:0.1 /kubefw --kubeconfig /kconfig --standalone` ``
+``docker start `docker create --net=host --rm --privileged -v ~/.kube/config:/kconfig -v /var/lib/kubernetes/:/var/lib/kubernetes/ -ti jpmondet/kubefw:0.1.2 /kubefw --kubeconfig /kconfig` ``
 
-(On the last command, `/var/lib/kubernetes` is only needed if your kubeconfig is pointing to certificates that are in that directory)
+(Mounting `/var/lib/kubernetes` is only needed if your kubeconfig is pointing to certificates that are in that directory)
 
-## Targets
+#### And after that ? 
 
-1. Simplified version of Kube-router just for Netpols (useful when using
-    a simple cni and/or to decouple networking & security)
-2. Should be runnable on any type of platform (not only k8s) but still based on the netpols of a k8s cluster (can be useful for tbshooting and to span the security policies outside the cluster).
-3. Allow an usage entirely decoupled from a k8s cluster.
+You are ready to use Network Policies as defined by Kubernetes.
 
-Heavily based on Kube-router codebase (but should diverge over time).
-Btw, you should take a look a their awesome project repo [kube-router](https://github.com/cloudnativelabs/kube-router)
+If you need example, you should take a look at this nice [cheatsheet/learning repo](https://github.com/ahmetb/kubernetes-network-policy-recipes) 
 
-## Current WIPs
+A quick example of a network policy that denies all traffic to an application
+would be : 
 
-* ~~Working version as a Daemonset inside a Kubernetes Cluster~~
-* ~~Withdraw the node-hostname dependency to be able to get all the iptables on 1 standalone machine~~
-* Try to translate netpols to get enhanced meaning for a remote machine
-* Could maybe also implement the iptables on different linux namespaces on the remote
-    machine (to avoid overriding/collisions)
-      Reminder : `sudo ip netns exec NS1 iptables`
+```yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: nginx-deny-all
+spec:
+  podSelector:
+    matchLabels:
+      run: nginx
+  ingress: []
+```
+
+## More about this project 
+
+This project may be useful when you are using a simple CNI plugin and/or to decouple Networking & Security (which should be a best practice in my point of view ;-) )
+
+Deploying KubeFW, even with default parameters will NOT mess up with your network plugin nor with your /etc/cni directory nor anything like that. This is
+safe.
+
+It WILL add `iptables` to your nodes depending on your Network Policies but will NOT override the `iptables` of the node itself (if it had any)
+
+There is another usage for servers outside Kubernetes but it's still a **WIP** (see [standalone_support](https://github.com/jpmondet/kubefw/tree/standalone_support) branch)
+
+This is **heavily** based on Kube-router codebase (but lighter and what's left is diverging over time).
+
+Btw, you should take a look a their awesome project repo [kube-router](https://github.com/cloudnativelabs/kube-router) if you need a fully fledge Network Plugin.
+


### PR DESCRIPTION
Showing Kubernetes branch on the master branch since it is stable and ready.

Leaving "standalone" usage on a branch for now.